### PR TITLE
Use ClusterIP instead of LoadBalancer for api Service

### DIFF
--- a/kubernetes/base/service.yaml
+++ b/kubernetes/base/service.yaml
@@ -12,7 +12,7 @@ spec:
         platform: sweetrpg
         package: library
         component: api
-    type: LoadBalancer
+    type: ClusterIP
     ports:
         - name: http
           port: 8281


### PR DESCRIPTION
## Summary
- Same issue as sweetrpg/catalog-api#120: the api Service was type: LoadBalancer, but nothing in this cluster provisions LoadBalancer IPs - traffic reaches it via the Traefik Ingress, which routes to the Service by ClusterIP regardless of type.
- status.loadBalancer.ingress never populates, so ArgoCD's built-in Service health check reports Progressing indefinitely instead of Healthy.
- Switches to ClusterIP.

## Test plan
- [ ] After sync, `kubectl get svc api-v1 -n sweetrpg-library` (or whatever the namespace is) shows ClusterIP with no External-IP
- [ ] ArgoCD shows the Service as Healthy, not Progressing